### PR TITLE
Set initial audio gain

### DIFF
--- a/menu.cpp
+++ b/menu.cpp
@@ -866,6 +866,7 @@ int ControlProc(MODULE* m, int msg, void* p1, void* p2)
 			data.sticky = 0;
 			data.mus_vol = 16; // 0..32
 			data.sfx_vol = 16; // 0..32
+			set_gain((data.mus_vol*100+16)/32,(data.sfx_vol*100+16)/32);
 
 			return 20;
 		}


### PR DESCRIPTION
Set audio gain on volume initialization, otherwise sound will be audible
only after a volume change.

This happens, at least, on Linux and web versions.