### PR TITLE
Add CMake, add MacOS support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,76 @@
+name: ci
+
+on:
+  push:
+    paths:
+      - "**.cpp"
+      - "**.cmake"
+      - "**/CMakeLists.txt"
+      - ".github/workflows/ci.yml"
+  pull_request:
+    paths:
+      - "**.cpp"
+      - "**.cmake"
+      - "**/CMakeLists.txt"
+      - ".github/workflows/ci.yml"
+
+jobs:
+
+  windows-msvc:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Configure
+      run: cmake -Bbuild -G "Visual Studio 17 2022"
+
+    - name: Build
+      run: cmake --build build --config Release --parallel
+
+  windows-gcc:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Configure
+      run: cmake -Bbuild -G "MinGW Makefiles"
+
+    - name: Build
+      run: cmake --build build --parallel
+
+  linux:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        cxx: [g++, clang++]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: install prereqs
+      run: |
+        sudo apt update
+        sudo apt install --no-install-recommends libxi-dev libx11-dev libpulse-dev
+
+    - name: Configure
+      run: cmake -Bbuild
+      env:
+        CXX: ${{ matrix.cxx }}
+
+    - name: Build
+      run: cmake --build build --parallel
+
+  mac:
+    runs-on: mac-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: install prereqs
+      run: brew install libxi libx11 pulseaudio
+
+    - name: Configure
+      run: cmake -Bbuild
+
+    - name: Build
+      run: cmake --build build --parallel

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,65 @@
+cmake_minimum_required(VERSION 3.14)
+
+project(ASCIIpatrol LANGUAGES CXX)
+
+option(web "build WASM using emscripten")
+
+# --- auto-ignore build directory
+if(NOT EXISTS ${PROJECT_BINARY_DIR}/.gitignore)
+  file(WRITE ${PROJECT_BINARY_DIR}/.gitignore "*")
+endif()
+
+# --- external libraries
+find_package(Threads)
+
+if(web)
+  find_path(EMSCRIPTEN_INCLUDE_DIR NAMES emscripten.h REQUIRED)
+elseif(UNIX)
+  find_package(X11 REQUIRED)
+  find_library(XI_LIBRARY NAMES Xi REQUIRED)
+  find_path(XI_INCLUDE_DIR NAMES X11/extensions/XInput2.h REQUIRED)
+  find_library(PULSEAUDIO_LIBRARY NAMES pulse REQUIRED)
+  find_path(PULSEAUDIO_INCLUDE_DIR NAMES pulse/pulseaudio.h REQUIRED)
+endif()
+
+# --- main program
+
+add_executable(asciipat
+manual.cpp mo3.cpp unmo3.cpp stb_vorbis.cpp
+conf.cpp gameover.cpp inter.cpp
+twister.cpp game.cpp temp.cpp menu.cpp assets.cpp
+)
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "(Clang|GNU)")
+  target_compile_options(asciipat PRIVATE -Wno-multichar)
+endif()
+
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
+set_target_properties(asciipat PROPERTIES CXX_STANDARD 98)
+# necessary for modern compilers that default to C++11 or newer such as Clang
+
+install(TARGETS asciipat)
+
+if(web)
+  target_compile_definitions(asciipat PRIVATE WEB)
+  target_sources(asciipat PRIVATE spec_web.cpp)
+	target_include_directories(asciipat PRIVATE ${EMSCRIPTEN_INCLUDE_DIR})
+elseif(UNIX)
+  target_compile_definitions(asciipat PRIVATE NIX)
+  target_sources(asciipat PRIVATE spec_nix.cpp)
+  target_link_libraries(asciipat PRIVATE X11::X11 ${XI_LIBRARY} ${PULSEAUDIO_LIBRARY})
+  target_include_directories(asciipat PRIVATE ${XI_INCLUDE_DIR} ${PULSEAUDIO_INCLUDE_DIR})
+elseif(WIN32)
+  target_compile_definitions(asciipat PRIVATE WIN
+  "$<$<BOOL:${MSVC}>:NOMINMAX;_CRT_SECURE_NO_WARNINGS>"
+  )
+  target_sources(asciipat PRIVATE spec_win.cpp)
+  target_link_libraries(asciipat PRIVATE dsound winmm gdi32 dxguid)
+else()
+  message(FATAL_ERROR "DOS is not yet handled.")
+endif()
+
+if(Threads_FOUND)
+  target_link_libraries(asciipat PRIVATE Threads::Threads)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,9 +36,6 @@ endif()
 
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
-set_target_properties(asciipat PROPERTIES CXX_STANDARD 98)
-# necessary for modern compilers that default to C++11 or newer such as Clang
-
 install(TARGETS asciipat)
 
 if(web)

--- a/README.md
+++ b/README.md
@@ -78,9 +78,13 @@ The needed libraries are installed like:
 ```sh
 # install required packages, (no apt-get -> use pacman)
 sudo apt-get install libx11-dev libpulse-dev
+# OR
+sudo dnf install libX11-devel pulseaudio-libs-devel
 
 # to fix problems with no keyboard input in few gnome terminals we require XI2
 sudo apt-get install libxi-dev
+# OR
+sudo dnf install libXi-devel
 ```
 
 Build with CMake:
@@ -121,6 +125,15 @@ Works with Visual Studio, MinGW / MSYS2, Cygwin, or WSL.
 
 ```sh
 cmake -Bbuild
+cmake --build build
+```
+
+### HTML5
+
+On a system with emscripten installed, build for HTML5 web browsers, producing "build/asciipat.[js,wasm]"
+
+```sh
+emcmake cmake -B build -Dweb=on
 cmake --build build
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,33 +1,38 @@
 
 # ascii-patrol
+
 Ascii Patrol is an ASCII game project. It was mainly inspired by "Moon Patrol", my favourite arcade game at the times I was a child.
 
 <img src="./ascii-patrol.gif" alt="ascii-patrol" width="100%" />
 
-Currently game can be built for 
-- Windows (VC2010)
-- Linux & Cygwin (GCC)
-- DOS (Watcom) 
+Currently game can be built using C++ compilers such as Clang, GCC, or Intel oneAPI including operating systems:
+
+- Windows (Visual Studio, Cygwin, MinGW, MSYS2, Windows Subsystem for Linux)
+- Linux, MacOS
+- DOS (Watcom)
 - HTML5 browsers (Emscripten)
 
 ## Version 1.7
+
 - Added $ASCII_PATROL_CONFIG_DIR and $ASCII_PATROL_RECORD_DIR environment variables (Linux only)
 
 ## Version 1.6
-- Thanks to XM player patch provided by @hexwab music sounds even better  
+
+- Thanks to XM player patch provided by @hexwab music sounds even better
   https://ascii-patrol.com/area54/ascii-patrol-html5.html
 
 ## Version 1.5
-- Mobile browsers can use touch input  
-  More on how to navigate & play using touch input is here:  
+
+- Mobile browsers can use touch input
+  More on how to navigate & play using touch input is here:
   https://ascii-patrol.com/forum/index.php?topic=71.0
-- It is possible to install game as PWA from:  
+- It is possible to install game as PWA from:
   https://ascii-patrol.com/area53/ascii-patrol-html5.html
 - You may also notice some vibrations bzzzz....
 
 To use / modify / add graphics asserts located in 'asset' directory you need to use [REXPaint](http://gridsagegames.com/rexpaint)
 Copy 'assets' directory to REXPaint's 'images' subdirectory. To apply modifications to the game, in next step you should use
-temp_xp program which converts all .xp files located in some directory to assets.cpp and assets.h files being compiled with game. 
+temp_xp program which converts all .xp files located in some directory to assets.cpp and assets.h files being compiled with game.
 
 [Ascii Patrol Home Page (ascii-patrol.com)](https://ascii-patrol.com)
 
@@ -37,42 +42,90 @@ AP can be easily built and runs great on Raspberry PI!
 Find me on Twitter: @MrGumix
 
 ## Give it a try on any HTML5 browser
-- https://ascii-patrol.com/area53/ascii-patrol-html5.html
+
+https://ascii-patrol.com/area53/ascii-patrol-html5.html
 
 ## Quick install on Linux with *snap*
+
 [![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-white.svg)](https://snapcraft.io/ascii-patrol)<br/>
 *snapped by @popey*
 - ```sudo snap install ascii-patrol```
 
+## Packages
 
-## Need a package? Try these:
 Arch Linux:
 - https://aur.archlinux.org/packages/ascii-patrol-git/
   by @SlavMetal
 - https://aur.archlinux.org/packages/ascii-patrol/
   by Towtow10 (only x64)
-  
-## Build instructions on Linux (assuming we have git and g++):
-```
+
+## Build instructions
+
+These instructions assume the system has Git and a C++ compiler.
+
+```sh
 # clone sources repo
 git clone https://github.com/msokalski/ascii-patrol.git
 
 # enter sources directory
 cd ascii-patrol
+```
 
-# enable execution of build.sh and run.sh scripts
-chmod +x *.sh
+### Linux
 
+The needed libraries are installed like:
+
+```sh
 # install required packages, (no apt-get -> use pacman)
 sudo apt-get install libx11-dev libpulse-dev
 
 # to fix problems with no keyboard input in few gnome terminals we require XI2
 sudo apt-get install libxi-dev
+```
 
+Build with CMake:
+
+```sh
+cmake -Bbuild
+cmake --build build
+```
+
+If the system doesn't have CMake:
+
+```sh
+# enable execution of build.sh and run.sh scripts
+chmod +x *.sh
 # invoke compilation
 ./build.sh
 ```
+
+### MacOS
+
+Homebrew install libraries (works with Clang or GCC):
+
+```sh
+brew install libxi pulseaudio
+```
+
+Build:
+
+```sh
+cmake -Bbuild
+cmake --build build
+```
+
+### Windows
+
+No extra libraries are needed on Windows.
+Works with Visual Studio, MinGW / MSYS2, Cygwin, or WSL.
+
+```sh
+cmake -Bbuild
+cmake --build build
+```
+
 ## Running
+
 Ascii Patrol uses curl to communicate with hi-score server (ascii-patrol.com)
 So optionally let's install it if needed.
 `sudo apt-get install curl`
@@ -85,6 +138,7 @@ or
 More on asciipat arguments can be found here: http://ascii-patrol.com/forum/index.php?topic=63
 
 ## Filepaths
+
 Ascii Patrol creates two files: _asciipat.cfg_ and _asciipat.rec_.
 
 _asciipat.cfg_ is created when you change your player name, avatar, or key bindings.
@@ -95,12 +149,9 @@ On Linux, by default, the game saves these files in $HOME. If $HOME is not set, 
 However, if $ASCII_PATROL_CONFIG_DIR or $ASCII_PATROL_RECORD_DIR are set, then the game will save the files in those directories respectively. The directories should already exist; Ascii Patrol will not create them.
 
 ## Problems?
+
 - no sound? -> install / start pulseaudio
 - weird colors? -> try another terminal emulator or run from raw console (ctrl-alt-F1 or so)
 - poor font look? -> try changing font in your terminal or in case of raw console use setfont
 - keyboard doesn't work? -> try another terminal emulator or run from raw console
 - no hi-scores table? -> install curl
-
-
-
-

--- a/inter.cpp
+++ b/inter.cpp
@@ -362,7 +362,7 @@ void DLG::Start(const char* txt, unsigned long t)
 	if (text)
 		delete [] text;
 	text=0;
-	
+
 	done=false;
 	start = t;
 	time = t;
@@ -549,7 +549,7 @@ void DLG::Paint(SCREEN* s, int x, int y, bool blend)
 			int ic = i-(16-nl)/2;
 			if (ic>=0 && ic<nl)
 				c=name[ic];
-			s->buf[dy*(s->w+1)+dx] = c; // < name 
+			s->buf[dy*(s->w+1)+dx] = c; // < name
 			if (s->color)
 			{
 				s->color[dy*(s->w+1)+dx] = xl;
@@ -662,8 +662,8 @@ INTER_MODAL::~INTER_MODAL()
 }
 
 INTER_MODAL::INTER_MODAL(SCREEN* _s,
-						 int _lives, int _startlives, int* _score, 
-						 const char* _course_name, const LEVEL* _current_level, 
+						 int _lives, int _startlives, int* _score,
+						 const char* _course_name, const LEVEL* _current_level,
 						 int _time, int _hitval, int _hitmax) :
 
 	dlg_player(&dialog_left, 20,5, 0x3B, conf_player.name, 18,2, &avatar, conf_player.avatar, 3,2, 40,12),
@@ -690,7 +690,7 @@ INTER_MODAL::INTER_MODAL(SCREEN* _s,
 	dialog_idx=0;
 	level = _current_level;
 
-	phase = -4; 
+	phase = -4;
 	phase_t = get_time();
 
 	dlg[0] = 0;
@@ -729,7 +729,7 @@ int INTER_MODAL::Run()
 	get_terminal_wh(&dw,&dh);
 	int nw = dw;
 	int nh = dh;
-		
+
 	if (nw>160)
 		nw=160;
 	if (nw<80)
@@ -746,7 +746,7 @@ int INTER_MODAL::Run()
 		h=nh;
 	}
 
-	unsigned long t = get_time();
+	unsigned int t = get_time();
 
 	inter_pos += t-prev_t;
 	if (inter_pos>inter_gap)
@@ -801,12 +801,12 @@ int INTER_MODAL::Run()
 		int duration = 500;
 		int d = duration;
 		int d2 = duration*duration;
-		int tm[4] = 
+		int tm[4] =
 		{
-			t-phase_t-0,
-			t-phase_t-0,
-			t-phase_t-0,
-			t-phase_t-0,
+			static_cast<int>(t-phase_t)-0,
+			static_cast<int>(t-phase_t)-0,
+			static_cast<int>(t-phase_t)-0,
+			static_cast<int>(t-phase_t)-0,
 		};
 
 		int pos = t-phase_t;
@@ -983,7 +983,7 @@ int INTER_MODAL::Run()
 		int d = 200;
 		int d2 = d*d;
 
-		int wait = 0; // extra time to wait 
+		int wait = 0; // extra time to wait
 
 		int pos = t-phase_t;
 		bool done=false;
@@ -998,12 +998,12 @@ int INTER_MODAL::Run()
 		{
 			// hide bonuses & score
 			int duration = 800;
-			int tm[4] = 
+			int tm[4] =
 			{
-				t-phase_t,
-				t-phase_t-200,
-				t-phase_t-100,
-				t-phase_t-300,
+				static_cast<int>(t-phase_t),
+				static_cast<int>(t-phase_t)-200,
+				static_cast<int>(t-phase_t)-100,
+				static_cast<int>(t-phase_t)-300,
 			};
 
 			//bool done=true;
@@ -1060,8 +1060,8 @@ int INTER_MODAL::Run()
 	else
 	if (phase==2)
 	{
-		// show full dialog text, 
-		// wait for key press then: 
+		// show full dialog text,
+		// wait for key press then:
 		// - if there are more dialogs then phase=3, otherwise phase = 4
 		// paint 'press any key'
 
@@ -1130,7 +1130,7 @@ int INTER_MODAL::Run()
 		pos = pos*(dlg_player.frame.height-2)/duration;
 
 		// swap dialog frames
-		// in the middle clear text in frame going down 
+		// in the middle clear text in frame going down
 
 		y0 += pos;
 		y1 -= pos;
@@ -1275,6 +1275,3 @@ int INTER_MODAL::Run()
 
 	return 0;
 }
-
-
-

--- a/spec_nix.cpp
+++ b/spec_nix.cpp
@@ -692,7 +692,7 @@ static int ansi_set_color_ex(int fg, int bg)
 	    return printf("\x1B[38;5;%d;48;5;%dm",fg%256,bg%256);
 
 	// bold & blink
-	return printf("\x1B[%d;%d;%s;%sm",fg%8+30,bg%8+40,fg<8?"21":"1",bg<8?"25":"5");
+	return printf("\x1B[%d;%d;%s;%sm",fg%8+30,bg%8+40,fg<8?"22":"1",bg<8?"25":"5");
 }
 
 static int ansi_set_color_rgb(int fg, int bg)

--- a/spec_win.cpp
+++ b/spec_win.cpp
@@ -995,7 +995,7 @@ int screen_write(CON_OUTPUT* screen, int dw, int dh, int sx, int sy, int sw, int
 		}
 	}
 
-	COORD size = { sw,sh };
+	COORD size = { static_cast<short int>(sw), static_cast<short int>(sh) };
 	COORD offs = { 0,0 };
 
 	CONSOLE_SCREEN_BUFFER_INFO sbi;
@@ -1003,7 +1003,8 @@ int screen_write(CON_OUTPUT* screen, int dw, int dh, int sx, int sy, int sw, int
     int dx = sbi.srWindow.Left;
     int dy = sbi.srWindow.Top;
 
-	SMALL_RECT rgn = {dx,dy,dx+sw-1,dy+sh-1};
+	SMALL_RECT rgn = {static_cast<short int>(dx), static_cast<short int>(dy),
+	static_cast<short int>(dx+sw-1), static_cast<short int>(dy+sh-1)};
 
 	//WriteConsoleOutputA(stdout_handle,arr,size,offs,&rgn);
 	WriteConsoleOutputW(stdout_handle,arr,size,offs,&rgn);

--- a/spec_win.cpp
+++ b/spec_win.cpp
@@ -2,6 +2,7 @@
 
 #ifdef WIN
 
+#include <algorithm>
 #include <windows.h>
 #include <Shlobj.h>
 #include <crtdbg.h>
@@ -98,14 +99,14 @@ DWORD WINAPI SoundProc(LPVOID p)
 	}
 
 	long vol = InterlockedExchange(&mo3_gain,-1);
-		
+
 	if (vol>=0)
 	{
 		DWORD db;
 
 		if(vol <= 0)
 			db = -10000;
-		else 
+		else
 		if(vol >= 100)
 			db = 0;
 		else
@@ -138,14 +139,14 @@ DWORD WINAPI SoundProc(LPVOID p)
 		idsb->GetCurrentPosition(&play_pos,&write_pos);
 
 		long vol = InterlockedExchange(&mo3_gain,-1);
-		
+
 		if (vol>=0)
 		{
 			DWORD db;
 
 			if(vol <= 0)
 			  db = -10000;
-			else 
+			else
 			if(vol >= 100)
 			  db = 0;
 			else
@@ -277,7 +278,7 @@ static CRITICAL_SECTION sfx_cs;
 static UINT sfx_timer=0;
 static int sfx_gain = 100;
 
-//SFXFader 
+//SFXFader
 
 void CALLBACK SFXFader(UINT uTimerID, UINT uMsg, DWORD_PTR dwUser, DWORD_PTR dw1, DWORD_PTR dw2)
 {
@@ -309,7 +310,7 @@ void CALLBACK SFXFader(UINT uTimerID, UINT uMsg, DWORD_PTR dwUser, DWORD_PTR dw1
 
 			if(gain <= 0)
 			  db = -10000;
-			else 
+			else
 			if(gain >= 1.0f)
 			  db = 0;
 			else
@@ -369,7 +370,7 @@ bool play_sfx(unsigned int id, void** voice, bool loop, int vol, int pan)
 			v->id = id;
 			v->voice = dup;
 			v->next = sfx_voice;
-			
+
 			v->vol  = sfx_gain;
 			v->gain = vol;
 			v->pan  = 0;
@@ -379,7 +380,7 @@ bool play_sfx(unsigned int id, void** voice, bool loop, int vol, int pan)
 
 			if(gain <= 0)
 			  db = -10000;
-			else 
+			else
 			if(gain >= 1.0f)
 			  db = 0;
 			else
@@ -566,7 +567,7 @@ bool set_sfx_params(void* voice, int vol, int pan)
 
 			if(gain <= 0)
 			  db = -10000;
-			else 
+			else
 			if(gain >= 1.0f)
 			  db = 0;
 			else
@@ -694,7 +695,7 @@ bool spec_read_input( CON_INPUT* ir, int n, int* r)
 	int i=0;
 	while (rem)
 	{
-		int s = (DWORD)min(rem,256);
+		int s = (DWORD)std::min(rem,256);
 		int win_r;
 		bool ok = !!ReadConsoleInputA(stdin_handle,win_ir,(DWORD)s,(DWORD*)&win_r);
 
@@ -765,12 +766,12 @@ bool spec_read_input( CON_INPUT* ir, int n, int* r)
 							case VK_DELETE:	code=KBD_DEL; break;
 							case VK_INSERT:	code=KBD_INS; break;
 
-							case VK_HOME:	
-								code=KBD_HOM; 
+							case VK_HOME:
+								code=KBD_HOM;
 								break;
 
-							case VK_END:	
-								code=KBD_END; 
+							case VK_END:
+								code=KBD_END;
 								break;
 
 							case VK_PRIOR:	code=KBD_PUP; break;
@@ -825,20 +826,20 @@ void get_terminal_wh(int* dw, int* dh)
 }
 
 static void SetConsolePalette(HANDLE sb, const void* palette)
-{ 
+{
 	HMODULE mod = GetModuleHandleA("kernel32.dll");
 	if (!mod)
 		return;
 
 	typedef BOOL (WINAPI *PGetConsoleScreenBufferInfoEx)(HANDLE hConsoleOutput, PCONSOLE_SCREEN_BUFFER_INFOEX lpConsoleScreenBufferInfoEx);
 	typedef BOOL (WINAPI *PSetConsoleScreenBufferInfoEx)(HANDLE hConsoleOutput, PCONSOLE_SCREEN_BUFFER_INFOEX lpConsoleScreenBufferInfoEx);
-    
-	PGetConsoleScreenBufferInfoEx pGetConsoleScreenBufferInfoEx = 
+
+	PGetConsoleScreenBufferInfoEx pGetConsoleScreenBufferInfoEx =
 		(PGetConsoleScreenBufferInfoEx)GetProcAddress(mod, "GetConsoleScreenBufferInfoEx");
 
-	PSetConsoleScreenBufferInfoEx pSetConsoleScreenBufferInfoEx = 
+	PSetConsoleScreenBufferInfoEx pSetConsoleScreenBufferInfoEx =
 		(PSetConsoleScreenBufferInfoEx)GetProcAddress(mod, "SetConsoleScreenBufferInfoEx");
-	
+
 	if (pGetConsoleScreenBufferInfoEx && pSetConsoleScreenBufferInfoEx)
 	{
 		CONSOLE_SCREEN_BUFFER_INFOEX nfo={0};
@@ -848,7 +849,7 @@ static void SetConsolePalette(HANDLE sb, const void* palette)
 		memcpy(nfo.ColorTable,palette,sizeof(COLORREF)*16);
 		ok = pSetConsoleScreenBufferInfoEx(sb,&nfo);
 	}
-} 
+}
 
 static const unsigned char ansi_pal[16*4] =
 {
@@ -903,8 +904,8 @@ int terminal_init(int argc, char* argv[], int* dw, int* dh)
 	CONSOLE_CURSOR_INFO ci={100,FALSE};
 	//SetConsoleCursorInfo(stdout_handle,&ci);
 
-	int cols = max(80,sbi.srWindow.Right - sbi.srWindow.Left + 1);
-    int rows = max(25,sbi.srWindow.Bottom - sbi.srWindow.Top + 1);
+	int cols = std::max(80,sbi.srWindow.Right - sbi.srWindow.Left + 1);
+    int rows = std::max(25,sbi.srWindow.Bottom - sbi.srWindow.Top + 1);
 
 	*dw = cols;
 	*dh = rows;
@@ -1003,7 +1004,7 @@ int screen_write(CON_OUTPUT* screen, int dw, int dh, int sx, int sy, int sw, int
     int dy = sbi.srWindow.Top;
 
 	SMALL_RECT rgn = {dx,dy,dx+sw-1,dy+sh-1};
-	
+
 	//WriteConsoleOutputA(stdout_handle,arr,size,offs,&rgn);
 	WriteConsoleOutputW(stdout_handle,arr,size,offs,&rgn);
 
@@ -1077,9 +1078,9 @@ DWORD WINAPI hiscore_proc(LPVOID p)
 							NULL,
 							NULL,
 							FALSE,
-							
+
 							// stop removing mouse feedback from my console!
-							DETACHED_PROCESS, 
+							DETACHED_PROCESS,
 
 							NULL,
 							NULL,
@@ -1151,7 +1152,7 @@ DWORD WINAPI hiscore_proc(LPVOID p)
 					}
 
 					// change last cr to eof
-					tmp.buf[55 * tmp.siz -1] = 0; 
+					tmp.buf[55 * tmp.siz -1] = 0;
 				}
 
 				fclose(f);
@@ -1205,7 +1206,7 @@ void request_hiscore(const char* cmd)
 
 		InitializeCriticalSection(&hiscore_cs);
 		hiscore_queue = 1;
-		DWORD id=0; 
+		DWORD id=0;
 		hiscore_thread = CreateThread(0,0,hiscore_proc, 0,0,&id);
 	}
 	else
@@ -1225,7 +1226,7 @@ void request_hiscore(const char* cmd)
 			strcpy_s(hiscore_data[0].buf,65*55,cmd);
 
 			hiscore_queue = 1;
-			DWORD id=0; 
+			DWORD id=0;
 			hiscore_thread = CreateThread(0,0,hiscore_proc, 0,0,&id);
 		}
 		else
@@ -1379,4 +1380,3 @@ void unlock_player()
 }
 
 #endif
-

--- a/temp.cpp
+++ b/temp.cpp
@@ -104,8 +104,8 @@ void MakeTerrain(const char* path, int len)
 	int hole_dist=80;
 
 	int crack_mod = 4;
-	
-	int hole_creature_mod = 1; 
+
+	int hole_creature_mod = 1;
 	int hole_edge_enemy_mod = 1;
 
 	int hole_edge_t=1;
@@ -420,7 +420,7 @@ void MakeTerrain(const char* path, int len)
 				epos = edge_right+2;
 			else
 			{
-				if (kind=='t') 
+				if (kind=='t')
 					epos = edge_right+2+30; // bit more space
 				else
 					epos = edge_right+2+20; // with landing place
@@ -832,15 +832,15 @@ struct CAMPAIGN_MODAL : MODAL
 					if (record_file)
 					{
 						int t;
-						
-						t=w^score; 
+
+						t=w^score;
 						crypt_enc(&t);
 						fwrite(&t,4,1,record_file);
-						
-						t=h^score; 
+
+						t=h^score;
 						crypt_enc(&t);
 						fwrite(&t,4,1,record_file);
-						
+
 						twister_write(record_file);
 
 						fclose(record_file);
@@ -866,13 +866,13 @@ struct CAMPAIGN_MODAL : MODAL
 					fopen_s(&record_file,record_path(),"ab");
 					if (record_file)
 					{
-						unsigned int chk[5] = 
+						unsigned int chk[5] =
 						{
-							twister_rand(),
-							twister_rand(),
+							static_cast<unsigned int>(twister_rand()),
+							static_cast<unsigned int>(twister_rand()),
 							crypt_chk(),
-							twister_rand(),
-							twister_rand()
+							static_cast<unsigned int>(twister_rand()),
+							static_cast<unsigned int>(twister_rand())
 						};
 
 						fwrite(chk,1,15+(rand()%5),record_file);
@@ -882,7 +882,7 @@ struct CAMPAIGN_MODAL : MODAL
 					// post recording to the server
 					// delete recording file?
 					post_hiscore();
-					
+
 					inter_modal = new GAMEOVER_MODAL(
 						&global_screen,
 						&score,
@@ -917,7 +917,7 @@ struct CAMPAIGN_MODAL : MODAL
 			///////////////////////////
 			// so ret is -1
 
-			// level finished. 
+			// level finished.
 			// prepare interscreen
 
 			// calc hitacc from hitbin
@@ -1031,15 +1031,15 @@ struct CAMPAIGN_MODAL : MODAL
 				{
 
 					int t;
-					
-					t=w^score; 
+
+					t=w^score;
 					crypt_enc(&t);
 					fwrite(&t,4,1,record_file);
-					
-					t=h^score; 
+
+					t=h^score;
 					crypt_enc(&t);
 					fwrite(&t,4,1,record_file);
-					
+
 					twister_write(record_file);
 
 					fclose(record_file);
@@ -1056,7 +1056,7 @@ struct CAMPAIGN_MODAL : MODAL
 					iSubLev, hitbin);
 				return -1;
 			}
-			
+
 			if (ret == -2)
 			{
 				// quit to menu?
@@ -1108,7 +1108,7 @@ struct MENU_MODAL : MODAL
 			{
 				// quit to menu doesn't change current play pattern
 				// ensures only we have full range loop
-				PlayLoop(0,-1,0,29);				
+				PlayLoop(0,-1,0,29);
 
 				// permanent end
 				if (hold_modal)
@@ -1222,7 +1222,7 @@ bool GameOnHold(int* course, int* level, int* sublevel, int* percent, int* score
 			LEVEL_MODAL* lm = (LEVEL_MODAL*)cm->level_modal;
 			if (lives)
 				*lives  = lm->lives; // this one is more fresh
-			
+
 
 			if (lm->t.check_passed+1 >= lm->t.check_points)
 			{
@@ -1377,7 +1377,7 @@ struct INTRO_MODAL : MODAL
 			int nw = dw;
 			int nh = dh;
 
-		
+
 			if (nw>160)
 				nw=160;
 			if (nw<80)
@@ -1467,7 +1467,7 @@ struct INTRO_MODAL : MODAL
 			afr = MIN(5,afr);
 
 			int ax = (s->w - (5*10-ascii_krn[4]))/2;
-		
+
 			int i=0;
 			for (; i<afr; i++)
 			{
@@ -1533,7 +1533,7 @@ INTRO_MODAL intro_modal;
 
 int FREAD(void* buf, int siz, int cnt, FILE* fil)
 {
-	if ( fread(buf,siz,cnt,fil) != cnt ) 
+	if ( fread(buf,siz,cnt,fil) != cnt )
 		exit(-1);
 	return cnt;
 }
@@ -1820,7 +1820,7 @@ int validate_score(const char* path, int* avatar, char* name)
 	delete level_modal;
 
 	fclose(record_file);
-	
+
 	return -1;
 }
 
@@ -2300,4 +2300,3 @@ void SetColorMode(unsigned char cl)
 		}
 	}
 }
-

--- a/unmo3.cpp
+++ b/unmo3.cpp
@@ -6,7 +6,7 @@
 
 #include <memory.h>
 #include <stdlib.h>
-#include <malloc.h>
+//#include <malloc.h>
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
@@ -123,7 +123,7 @@ unsigned char * mo3_unpack(unsigned char *src, unsigned char *dst, mo3_long size
   }
 
 
-  if ( (dst-initDst)!=initSize ) 
+  if ( (dst-initDst)!=initSize )
   {
   }
 
@@ -169,11 +169,11 @@ bool OpenSong(SONG* song)
 	unsigned char* song_seq = hdr_ptr;
 	hdr_ptr += nfo->song_len;
 
-	// voice seq (for each pattern, and each channel, number of voice data) : identical voices are detected and factorized at compression. 
+	// voice seq (for each pattern, and each channel, number of voice data) : identical voices are detected and factorized at compression.
 	unsigned short* voice_seq = (unsigned short*)hdr_ptr;
 	hdr_ptr += 2 * nfo->patterns * nfo->channels;
 
-	// pattern length table (size=nb_patt*2) 
+	// pattern length table (size=nb_patt*2)
 	unsigned short* pattern_len = (unsigned short*)hdr_ptr;
 	hdr_ptr += 2*nfo->patterns;
 
@@ -240,7 +240,7 @@ bool OpenSong(SONG* song)
 
 		// warning, we are overwriting unused part of decded data!
 		sample_data[i]->ogg_header = i;
-		if ( file_hdr->ver>=5 && (sample_data[i]->flags&0x5000) == 0x5000 ) 
+		if ( file_hdr->ver>=5 && (sample_data[i]->flags&0x5000) == 0x5000 )
 		{
 		  sample_data[i]->ogg_header = GET_WORD(hdr_ptr);
 		  hdr_ptr+=2;
@@ -500,7 +500,7 @@ int XMChannel::Smp(float t)
 	if (sample->flags & 0x0010)
 	{
 		// loop enabled
-		if (sample->flags & 0x0020) 
+		if (sample->flags & 0x0020)
 		{
 			// bidi loop
 			if (t1>=sample->end)
@@ -556,7 +556,7 @@ struct XMPlayer
 	SONG song;
 
 	int song_seq;	// song position ( % song->nfo->song_len )
-	int pattern;	// current pattern 
+	int pattern;	// current pattern
 	int row;		// processed in current pattern ( % song->pattern_len[pattern] )
 	int tick;		// processed in current row ( % song->nfo->ticks_per_row )
 
@@ -579,7 +579,7 @@ struct XMPlayer
 	int fade_ofs;
 
 	int cmd_sync; // -1 nutting
-	int cmd_start; 
+	int cmd_start;
 	int cmd_loop_a;
 	int cmd_loop_b;
 
@@ -781,7 +781,7 @@ void XMPlayer::Row()
 	sprintf_s(r,32,"%02d / %02d : ", pattern, row);
 	OutputDebugStringA(r);
 
-	// main task is to advance 
+	// main task is to advance
 	for (int c=0; c<song.nfo->channels; c++)
 	{
 		if (!chn[c].voice_ptr)
@@ -806,7 +806,7 @@ void XMPlayer::Row()
 		chn[c].row_reps++;
 
 		int pairs = n&0x0F;
-		
+
 		if (pairs)
 		{
 			Cmd(c,ptr,pairs);
@@ -836,7 +836,7 @@ const static char* notes[12]=
 	"D-",
 	 	"D#",
 	"E-",
-	 
+
 	"F-",
 	 	"F#",
 	"G-",
@@ -880,25 +880,25 @@ void XMPlayer::Cmd(int c, unsigned char* data, int pairs)
 				{
 					dbg[0]='X';
 					dbg[1]='X';
-					dbg[2]='X';				
+					dbg[2]='X';
 				}
 				else if (key==0xfe)
 				{
 					dbg[0]='^';
 					dbg[1]='^';
-					dbg[2]='^';				
+					dbg[2]='^';
 				}
 				else if (chn[c].sample && !porta)
 				{
 					// if prev note is still alive
-					// we should move its context to nano-fadeout 
+					// we should move its context to nano-fadeout
 					// current params with upto 1-tick fade during mixing
 
 					int fade_ch = c+song.nfo->channels;
 					chn[fade_ch] = chn[c];
 
 					// here we store fade progress in output samples
-					chn[fade_ch].vol_slide = 0; 
+					chn[fade_ch].vol_slide = 0;
 
 					// clear others
 					chn[fade_ch].tone_porta=0;
@@ -1169,7 +1169,7 @@ void XMPlayer::Mix(int ch, int frq, short* buffer, int samples)
 				float scale = chn[c].frq / frq;
 
 				// norm = 256*64
-				int vol0 = amp0 * ext_vol * chn[c].vol0*chn[c].evol0 / 65536; 
+				int vol0 = amp0 * ext_vol * chn[c].vol0*chn[c].evol0 / 65536;
 				int vol1 = amp1 * ext_vol * chn[c].vol*chn[c].evol1 / 65536;
 
 				if (c>=song.nfo->channels)
@@ -1183,7 +1183,7 @@ void XMPlayer::Mix(int ch, int frq, short* buffer, int samples)
 
 						// APPLY TCK interpolator (mono)
 						int vol = vol0 + (vol1-vol0) * (xm_player.aud_rem+i)/tick_samples;
-						
+
 						a = buffer[i] + a*vol / (256*64);
 
 						if (a>32767)


### PR DESCRIPTION
CMake optionally added. This makes supporting the multiple OS easier. MacOS, Visual Studio, MinGW/MSYS2, Intel oneAPI, Clang, GCC, Emscripten, etc. supported.

I didn't put DOS into CMake yet. 

I made several tweaks to source code to correct errors on various compilers. 
In particular, static_cast was used to make the source C++11 and newer compliant, to avoid need to set special compiler fallback options.

I also added CI build tests across OS and compiler. I didn't quite figure out how to run the program in headless mode. I saw the forum instructions but the "asciipat 0 foo.rec" instantly exited without seeming to do anything.